### PR TITLE
Add interactive web UI for managing words

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,14 +1,36 @@
+from pathlib import Path
+import sys
+
 from fastapi import FastAPI
+from fastapi.responses import FileResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
+
+BASE_DIR = Path(__file__).resolve().parent
+STATIC_DIR = BASE_DIR / "static"
+
+if str(BASE_DIR) not in sys.path:
+    sys.path.append(str(BASE_DIR))
+
 from routers import folders, groups, words, profiles, quizzes
 
 app = FastAPI(title="Remember Word", version="1.0")
 
-@app.get("/")
+if STATIC_DIR.exists():
+    app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+
+
+@app.get("/", response_class=FileResponse)
 def root():
-    return {"message": "Remember Word API running on port 8080"}
+    """Serve the single page application for the Remember Word project."""
+    index_path = STATIC_DIR / "index.html"
+    if not index_path.exists():
+        # Fallback to previous JSON response when the front-end is missing
+        return JSONResponse({"message": "Remember Word API running on port 8080"})
+    return FileResponse(index_path)
+
 
 app.include_router(folders.router, prefix="/folders", tags=["folders"])
-app.include_router(groups.router,  prefix="/groups",  tags=["groups"])
-app.include_router(words.router,   prefix="/words",   tags=["words"])
+app.include_router(groups.router, prefix="/groups", tags=["groups"])
+app.include_router(words.router, prefix="/words", tags=["words"])
 app.include_router(profiles.router, prefix="/profiles", tags=["profiles"])
-app.include_router(quizzes.router,  prefix="/quizzes",  tags=["quizzes"])
+app.include_router(quizzes.router, prefix="/quizzes", tags=["quizzes"])

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Remember Word</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Remember Word</h1>
+      <p>폴더와 그룹을 만들고 단어를 추가해보세요.</p>
+    </header>
+
+    <main>
+      <section id="folders" class="panel">
+        <div class="panel-header">
+          <h2>폴더</h2>
+          <button id="refresh-folders" class="secondary">새로고침</button>
+        </div>
+        <ul id="folder-list" class="list"></ul>
+        <form id="folder-form" class="form">
+          <h3>새 폴더 만들기</h3>
+          <label>
+            이름
+            <input name="name" type="text" placeholder="예: 영어 어휘" required />
+          </label>
+          <button type="submit">추가</button>
+        </form>
+      </section>
+
+      <section id="groups" class="panel">
+        <div class="panel-header">
+          <h2>그룹</h2>
+          <span class="panel-subtitle" id="groups-subtitle">폴더를 선택하세요</span>
+        </div>
+        <ul id="group-list" class="list"></ul>
+        <form id="group-form" class="form">
+          <h3>새 그룹 만들기</h3>
+          <label>
+            이름
+            <input name="name" type="text" placeholder="예: Day 1" required />
+          </label>
+          <button type="submit">추가</button>
+        </form>
+      </section>
+
+      <section id="words" class="panel">
+        <div class="panel-header">
+          <h2>단어</h2>
+          <div class="word-controls">
+            <label>
+              최소 별점
+              <select id="word-min-star">
+                <option value="">전체</option>
+                <option value="0">0</option>
+                <option value="1">1</option>
+                <option value="2">2</option>
+                <option value="3">3</option>
+                <option value="4">4</option>
+                <option value="5">5</option>
+              </select>
+            </label>
+            <button id="refresh-words" class="secondary">필터 적용</button>
+          </div>
+        </div>
+
+        <div class="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>언어</th>
+                <th>단어</th>
+                <th>뜻</th>
+                <th>별</th>
+              </tr>
+            </thead>
+            <tbody id="word-table"></tbody>
+          </table>
+        </div>
+
+        <form id="word-form" class="form">
+          <h3>단어 추가</h3>
+          <div class="grid">
+            <label>
+              언어
+              <input name="language" type="text" value="en" />
+            </label>
+            <label>
+              단어
+              <input name="term" type="text" required />
+            </label>
+            <label>
+              뜻
+              <input name="meaning" type="text" required />
+            </label>
+            <label>
+              별점 (0-5)
+              <input name="star" type="number" min="0" max="5" value="0" />
+            </label>
+          </div>
+          <label>
+            메모
+            <textarea name="memo" rows="2" placeholder="예문이나 메모"></textarea>
+          </label>
+          <button type="submit">추가</button>
+        </form>
+      </section>
+    </main>
+
+    <div id="toast" role="status" aria-live="polite"></div>
+
+    <script src="/static/main.js" defer></script>
+  </body>
+</html>

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -1,0 +1,301 @@
+const state = {
+  folders: [],
+  groups: [],
+  words: [],
+  activeFolderId: null,
+  activeGroupId: null,
+};
+
+const folderList = document.querySelector('#folder-list');
+const groupList = document.querySelector('#group-list');
+const wordTable = document.querySelector('#word-table');
+const groupsSubtitle = document.querySelector('#groups-subtitle');
+const toast = document.querySelector('#toast');
+const minStarSelect = document.querySelector('#word-min-star');
+
+function showToast(message, type = 'info') {
+  toast.textContent = message;
+  toast.dataset.type = type;
+  toast.classList.add('show');
+  setTimeout(() => toast.classList.remove('show'), 2400);
+}
+
+async function api(path, options = {}) {
+  const res = await fetch(path, {
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    ...options,
+  });
+  if (!res.ok) {
+    let detail = '요청 중 오류가 발생했습니다.';
+    try {
+      const data = await res.json();
+      detail = data.detail || JSON.stringify(data);
+    } catch (err) {
+      // ignore parse error
+    }
+    throw new Error(detail);
+  }
+  const text = await res.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function renderFolders() {
+  folderList.innerHTML = '';
+  if (state.folders.length === 0) {
+    folderList.innerHTML = '<li class="empty">등록된 폴더가 없습니다.</li>';
+    return;
+  }
+  state.folders.forEach((folder) => {
+    const li = document.createElement('li');
+    li.dataset.id = folder.id;
+    li.innerHTML = `<span class="name">${folder.name}</span>`;
+    if (state.activeFolderId === folder.id) {
+      li.classList.add('active');
+    }
+    li.addEventListener('click', () => selectFolder(folder.id));
+    folderList.appendChild(li);
+  });
+}
+
+function renderGroups() {
+  groupList.innerHTML = '';
+  if (!state.activeFolderId) {
+    groupList.innerHTML = '<li class="empty">왼쪽에서 폴더를 선택하세요.</li>';
+    groupsSubtitle.textContent = '폴더를 선택하세요';
+    return;
+  }
+  groupsSubtitle.textContent = `선택한 폴더 ID: ${state.activeFolderId}`;
+  if (state.groups.length === 0) {
+    groupList.innerHTML = '<li class="empty">아직 그룹이 없습니다.</li>';
+    return;
+  }
+  state.groups.forEach((group) => {
+    const li = document.createElement('li');
+    li.dataset.id = group.id;
+    li.innerHTML = `<span class="name">${group.name}</span>`;
+    if (state.activeGroupId === group.id) {
+      li.classList.add('active');
+    }
+    li.addEventListener('click', () => selectGroup(group.id));
+    groupList.appendChild(li);
+  });
+}
+
+function renderWords() {
+  wordTable.innerHTML = '';
+  if (!state.activeGroupId) {
+    wordTable.innerHTML = '<tr><td colspan="4">그룹을 선택하면 단어가 표시됩니다.</td></tr>';
+    return;
+  }
+  if (state.words.length === 0) {
+    wordTable.innerHTML = '<tr><td colspan="4">등록된 단어가 없습니다.</td></tr>';
+    return;
+  }
+  state.words.forEach((word) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${word.language}</td>
+      <td>${word.term}</td>
+      <td>${word.meaning}</td>
+      <td>
+        <div class="star-cell" data-id="${word.id}">
+          <span class="star-value">${word.star}</span>
+          <button class="star-up" title="별점 +1">▲</button>
+          <button class="star-down" title="별점 -1">▼</button>
+        </div>
+      </td>
+    `;
+    wordTable.appendChild(tr);
+  });
+}
+
+async function fetchFolders() {
+  try {
+    const data = await api('/folders');
+    state.folders = data;
+    if (!state.folders.find((f) => f.id === state.activeFolderId)) {
+      state.activeFolderId = null;
+      state.groups = [];
+      state.activeGroupId = null;
+      state.words = [];
+    }
+    renderFolders();
+    renderGroups();
+    renderWords();
+  } catch (err) {
+    showToast(err.message, 'error');
+  }
+}
+
+async function fetchGroups() {
+  if (!state.activeFolderId) return;
+  try {
+    const data = await api(`/groups?folder_id=${state.activeFolderId}`);
+    state.groups = data;
+    if (!state.groups.find((g) => g.id === state.activeGroupId)) {
+      state.activeGroupId = null;
+      state.words = [];
+    }
+    renderGroups();
+    renderWords();
+  } catch (err) {
+    showToast(err.message, 'error');
+  }
+}
+
+async function fetchWords() {
+  if (!state.activeGroupId) return;
+  const minStar = minStarSelect.value;
+  const params = new URLSearchParams({ group_id: state.activeGroupId });
+  if (minStar !== '') params.append('min_star', minStar);
+  try {
+    const data = await api(`/words?${params.toString()}`);
+    state.words = data;
+    renderWords();
+  } catch (err) {
+    showToast(err.message, 'error');
+  }
+}
+
+async function selectFolder(id) {
+  state.activeFolderId = id;
+  state.activeGroupId = null;
+  state.words = [];
+  renderFolders();
+  renderGroups();
+  renderWords();
+  await fetchGroups();
+}
+
+async function selectGroup(id) {
+  state.activeGroupId = id;
+  renderGroups();
+  await fetchWords();
+}
+
+async function handleFolderSubmit(event) {
+  event.preventDefault();
+  const form = event.currentTarget;
+  const formData = new FormData(form);
+  const name = formData.get('name').trim();
+  if (!name) return;
+  try {
+    await api('/folders', {
+      method: 'POST',
+      body: JSON.stringify({ name }),
+    });
+    form.reset();
+    showToast('폴더가 추가되었습니다.');
+    await fetchFolders();
+  } catch (err) {
+    showToast(err.message, 'error');
+  }
+}
+
+async function handleGroupSubmit(event) {
+  event.preventDefault();
+  if (!state.activeFolderId) {
+    showToast('먼저 폴더를 선택하세요.', 'error');
+    return;
+  }
+  const form = event.currentTarget;
+  const formData = new FormData(form);
+  const name = formData.get('name').trim();
+  if (!name) return;
+  try {
+    await api('/groups', {
+      method: 'POST',
+      body: JSON.stringify({ name, folder_id: state.activeFolderId }),
+    });
+    form.reset();
+    showToast('그룹이 추가되었습니다.');
+    await fetchGroups();
+  } catch (err) {
+    showToast(err.message, 'error');
+  }
+}
+
+async function handleWordSubmit(event) {
+  event.preventDefault();
+  if (!state.activeGroupId) {
+    showToast('먼저 그룹을 선택하세요.', 'error');
+    return;
+  }
+  const form = event.currentTarget;
+  const formData = new FormData(form);
+  const payload = {
+    group_id: state.activeGroupId,
+    language: formData.get('language') || 'en',
+    term: formData.get('term').trim(),
+    meaning: formData.get('meaning').trim(),
+    memo: formData.get('memo').trim() || null,
+    star: Number(formData.get('star') || 0),
+  };
+  if (!payload.term || !payload.meaning) {
+    showToast('단어와 뜻을 입력하세요.', 'error');
+    return;
+  }
+  try {
+    await api('/words', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+    form.reset();
+    form.elements.language.value = 'en';
+    form.elements.star.value = '0';
+    showToast('단어가 추가되었습니다.');
+    await fetchWords();
+  } catch (err) {
+    showToast(err.message, 'error');
+  }
+}
+
+async function changeStar(wordId, delta) {
+  const word = state.words.find((w) => w.id === wordId);
+  if (!word) return;
+  const next = Math.min(5, Math.max(0, word.star + delta));
+  if (next === word.star) return;
+  try {
+    const updated = await api(`/words/${wordId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ star: next }),
+    });
+    const idx = state.words.findIndex((w) => w.id === wordId);
+    if (idx >= 0) state.words[idx] = updated;
+    renderWords();
+    showToast('별점이 업데이트되었습니다.');
+  } catch (err) {
+    showToast(err.message, 'error');
+  }
+}
+
+function handleWordTableClick(event) {
+  const container = event.target.closest('.star-cell');
+  if (!container) return;
+  const wordId = Number(container.dataset.id);
+  if (event.target.matches('.star-up')) {
+    changeStar(wordId, +1);
+  } else if (event.target.matches('.star-down')) {
+    changeStar(wordId, -1);
+  }
+}
+
+function init() {
+  document.querySelector('#folder-form').addEventListener('submit', handleFolderSubmit);
+  document.querySelector('#group-form').addEventListener('submit', handleGroupSubmit);
+  document.querySelector('#word-form').addEventListener('submit', handleWordSubmit);
+  document.querySelector('#refresh-folders').addEventListener('click', fetchFolders);
+  document.querySelector('#refresh-words').addEventListener('click', (event) => {
+    event.preventDefault();
+    fetchWords();
+  });
+  wordTable.addEventListener('click', handleWordTableClick);
+  fetchFolders();
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,0 +1,239 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Pretendard", "Segoe UI", sans-serif;
+  background: #f4f5f7;
+  color: #1e1f24;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f8f9fb 0%, #eaeef8 100%);
+}
+
+header {
+  padding: 1.5rem 2rem;
+  background: #243b53;
+  color: white;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+header h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.8rem;
+}
+
+header p {
+  margin: 0;
+  opacity: 0.85;
+}
+
+main {
+  display: grid;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.panel {
+  background: white;
+  border-radius: 14px;
+  box-shadow: 0 18px 30px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-height: 320px;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.panel-subtitle {
+  font-size: 0.85rem;
+  color: #52606d;
+}
+
+.list {
+  flex: 1;
+  list-style: none;
+  margin: 0;
+  padding: 0.5rem 0;
+  overflow-y: auto;
+}
+
+.list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  border-left: 4px solid transparent;
+}
+
+.list li:hover {
+  background: rgba(100, 116, 139, 0.08);
+}
+
+.list li.active {
+  background: rgba(37, 99, 235, 0.12);
+  border-left-color: #2563eb;
+}
+
+.list li span.name {
+  font-weight: 600;
+}
+
+.form {
+  padding: 1rem 1.25rem 1.5rem;
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.form h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: #243b53;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.9rem;
+  gap: 0.35rem;
+  color: #334155;
+}
+
+input,
+select,
+textarea,
+button {
+  font: inherit;
+}
+
+input,
+select,
+textarea {
+  padding: 0.55rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  background: rgba(255, 255, 255, 0.9);
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+  outline: none;
+}
+
+button {
+  cursor: pointer;
+  border: none;
+  border-radius: 8px;
+  padding: 0.65rem 1rem;
+  background: #2563eb;
+  color: white;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+button.secondary {
+  background: rgba(37, 99, 235, 0.1);
+  color: #1f2937;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.2);
+}
+
+.table-wrapper {
+  overflow: auto;
+  padding: 0 1.25rem 1.25rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+thead tr {
+  background: rgba(37, 99, 235, 0.08);
+}
+
+thead th {
+  padding: 0.6rem;
+  text-align: left;
+  color: #1f2937;
+}
+
+tbody td {
+  padding: 0.55rem 0.6rem;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.9);
+}
+
+tbody tr:hover {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.word-controls {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+#toast {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  background: #1f2937;
+  color: white;
+  padding: 0.85rem 1.25rem;
+  border-radius: 999px;
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.25s ease, transform 0.25s ease;
+  pointer-events: none;
+}
+
+#toast.show {
+  opacity: 0.95;
+  transform: translateY(0);
+}
+
+@media (max-width: 768px) {
+  header {
+    text-align: center;
+  }
+
+  .panel {
+    min-height: 280px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static single-page interface that lets users manage folders, groups, and words from the browser
- serve the new frontend via FastAPI by mounting the static directory at the root route

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e4e3ba601c832397a0274636afd4b2