### PR TITLE
Ensure quiz tables are created on startup

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -11,19 +11,30 @@ Base = declarative_base()
 
 def ensure_schema() -> None:
     """Ensure the runtime database schema matches the ORM models."""
-    with engine.connect() as connection:
+
+    # Importing inside the function avoids circular import issues because models.py
+    # depends on ``Base`` from this module. The import ensures the metadata for all
+    # ORM models (including newly added ones) is loaded before ``create_all`` runs.
+    from models import Base as ModelBase  # pylint: disable=import-outside-toplevel
+
+    with engine.begin() as connection:
+        # Create any tables that do not yet exist. ``create_all`` is idempotent so
+        # running it on every startup is safe and prevents "relation does not
+        # exist" errors when new tables (e.g. quiz_sessions) are introduced.
+        ModelBase.metadata.create_all(bind=connection)
+
         inspector = inspect(connection)
         try:
             columns = {column["name"] for column in inspector.get_columns("words")}
         except NoSuchTableError:
-            # The tables haven't been created yet. create_tables.py will handle it.
+            # If the words table is still missing we cannot apply column migrations.
+            # ``create_all`` above should normally prevent this path.
             return
 
         if "star" not in columns:
             connection.execute(
                 text("ALTER TABLE words ADD COLUMN star INTEGER NOT NULL DEFAULT 0")
             )
-            connection.commit()
 
 
 def get_db():


### PR DESCRIPTION
## Summary
- create missing database tables during application startup to prevent quiz session errors
- keep existing schema migration for the words.star column intact

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e4e9d26f8883239206a9ade54743d4