### PR TITLE
Lower minimum Python version requirement for create_tables

### DIFF
--- a/app/create_tables.py
+++ b/app/create_tables.py
@@ -3,7 +3,7 @@
 import sys
 
 
-MIN_PYTHON = (3, 8)
+MIN_PYTHON = (3, 7)
 
 if sys.version_info < MIN_PYTHON:
     raise SystemExit(


### PR DESCRIPTION
## Summary
- reduce the minimum supported Python version for the table creation utility to 3.7 so the script runs on more environments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4eb8191208323813c90aa34f4ba4f