### PR TITLE
Improve word list layout for easier browsing

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -24,14 +24,17 @@
           <button id="refresh-folders" class="secondary">새로고침</button>
         </div>
         <ul id="folder-list" class="list"></ul>
-        <form id="folder-form" class="form">
-          <h3>새 폴더 만들기</h3>
-          <label>
-            이름
-            <input name="name" type="text" placeholder="예: 영어 어휘" required />
-          </label>
-          <button type="submit">추가</button>
-        </form>
+        <details class="form-details">
+          <summary>+ 새 폴더 만들기</summary>
+          <form id="folder-form" class="form">
+            <h3>새 폴더 만들기</h3>
+            <label>
+              이름
+              <input name="name" type="text" placeholder="예: 영어 어휘" required />
+            </label>
+            <button type="submit">추가</button>
+          </form>
+        </details>
       </section>
 
       <section id="groups" class="panel">
@@ -40,14 +43,17 @@
           <span class="panel-subtitle" id="groups-subtitle">폴더를 선택하세요</span>
         </div>
         <ul id="group-list" class="list"></ul>
-        <form id="group-form" class="form">
-          <h3>새 그룹 만들기</h3>
-          <label>
-            이름
-            <input name="name" type="text" placeholder="예: Day 1" required />
-          </label>
-          <button type="submit">추가</button>
-        </form>
+        <details class="form-details">
+          <summary>+ 새 그룹 만들기</summary>
+          <form id="group-form" class="form">
+            <h3>새 그룹 만들기</h3>
+            <label>
+              이름
+              <input name="name" type="text" placeholder="예: Day 1" required />
+            </label>
+            <button type="submit">추가</button>
+          </form>
+        </details>
       </section>
 
       <section id="words" class="panel">
@@ -85,46 +91,52 @@
           </table>
         </div>
 
-        <form id="word-form" class="form">
-          <h3>단어 추가</h3>
-          <div class="grid">
+        <details class="form-details">
+          <summary>+ 단어 추가</summary>
+          <form id="word-form" class="form">
+            <h3>단어 추가</h3>
+            <div class="grid">
+              <label>
+                언어
+                <input name="language" type="text" value="en" />
+              </label>
+              <label>
+                단어
+                <input name="term" type="text" required />
+              </label>
+              <label>
+                뜻
+                <input name="meaning" type="text" required />
+              </label>
+              <label>
+                별점 (0-5)
+                <input name="star" type="number" min="0" max="5" value="0" />
+              </label>
+            </div>
             <label>
-              언어
-              <input name="language" type="text" value="en" />
+              메모
+              <textarea name="memo" rows="2" placeholder="예문이나 메모"></textarea>
             </label>
-            <label>
-              단어
-              <input name="term" type="text" required />
-            </label>
-            <label>
-              뜻
-              <input name="meaning" type="text" required />
-            </label>
-            <label>
-              별점 (0-5)
-              <input name="star" type="number" min="0" max="5" value="0" />
-            </label>
-          </div>
-          <label>
-            메모
-            <textarea name="memo" rows="2" placeholder="예문이나 메모"></textarea>
-          </label>
-          <button type="submit">추가</button>
-        </form>
+            <button type="submit">추가</button>
+          </form>
+        </details>
 
-        <form id="import-form" class="form">
-          <h3>엑셀로 단어 가져오기</h3>
-          <p class="form-description">엑셀 파일에 폴더, 그룹, 단어, 뜻 열을 포함하여 업로드하세요.</p>
-          <label>
-            기본 언어 (선택)
-            <input id="import-language" type="text" value="en" />
-          </label>
-          <label>
-            파일 선택
-            <input id="import-file" name="file" type="file" accept=".xlsx,.xls,.csv" required />
-          </label>
-          <button type="submit">업로드</button>
-        </form>
+        <details class="form-details">
+          <summary>⤴︎ 엑셀로 단어 가져오기</summary>
+          <form id="import-form" class="form">
+            <h3>엑셀로 단어 가져오기</h3>
+            <p class="form-description">엑셀 파일에 폴더, 그룹, 단어, 뜻 열을 포함하여 업로드하세요.</p>
+            <label>
+              기본 언어 (선택)
+              <input id="import-language" type="text" value="en" />
+            </label>
+            <label>
+              파일 선택
+              <input id="import-file" name="file" type="file" accept=".xlsx,.xls,.csv" required />
+            </label>
+            <button type="submit">업로드</button>
+          </form>
+        </details>
       </section>
     </main>
 

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -58,7 +58,26 @@ main {
   display: grid;
   gap: 1.5rem;
   padding: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: minmax(260px, 320px) minmax(420px, 1fr);
+  grid-template-areas:
+    "folders words"
+    "groups words";
+  grid-auto-rows: minmax(280px, 1fr);
+  align-items: stretch;
+  min-height: calc(100vh - 6rem);
+}
+
+#folders {
+  grid-area: folders;
+}
+
+#groups {
+  grid-area: groups;
+}
+
+#words {
+  grid-area: words;
+  min-height: 100%;
 }
 
 .panel {
@@ -69,6 +88,16 @@ main {
   flex-direction: column;
   overflow: hidden;
   min-height: 320px;
+}
+
+.panel > .list {
+  padding: 0.5rem 0;
+}
+
+.panel > .list,
+.panel > .table-wrapper {
+  flex: 1;
+  min-height: 0;
 }
 
 .panel-header {
@@ -233,6 +262,8 @@ button:hover:not(:disabled) {
 .table-wrapper {
   overflow: auto;
   padding: 0 1.25rem 1.25rem;
+  display: flex;
+  flex-direction: column;
 }
 
 table {
@@ -249,11 +280,17 @@ thead th {
   padding: 0.6rem;
   text-align: left;
   color: #1f2937;
+  position: sticky;
+  top: 0;
+  background: rgba(248, 250, 252, 0.95);
+  backdrop-filter: blur(4px);
+  z-index: 1;
 }
 
 tbody td {
   padding: 0.55rem 0.6rem;
   border-bottom: 1px solid rgba(226, 232, 240, 0.9);
+  vertical-align: top;
 }
 
 tbody tr:hover {
@@ -285,6 +322,56 @@ tbody tr:hover {
 
 .hidden {
   display: none !important;
+}
+
+.form-details {
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(248, 250, 252, 0.75);
+}
+
+.form-details + .form-details {
+  border-top: none;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.form-details summary {
+  list-style: none;
+  cursor: pointer;
+  font-weight: 600;
+  color: #1f2937;
+  padding: 0.9rem 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.form-details summary::-webkit-details-marker {
+  display: none;
+}
+
+.form-details summary::after {
+  content: '열기';
+  font-size: 0.8rem;
+  color: #475569;
+}
+
+.form-details[open] summary {
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.form-details[open] summary::after {
+  content: '닫기';
+  color: #2563eb;
+}
+
+.form-details .form {
+  border-top: 1px solid rgba(37, 99, 235, 0.15);
+  padding-top: 1.25rem;
+}
+
+.form-details[open] + .form-details {
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
 }
 
 .quiz-content {
@@ -388,6 +475,19 @@ tbody tr:hover {
 }
 
 @media (max-width: 768px) {
+  main {
+    grid-template-columns: 1fr;
+    grid-template-areas: none;
+    grid-auto-rows: auto;
+    min-height: auto;
+  }
+
+  #folders,
+  #groups,
+  #words {
+    grid-area: auto;
+  }
+
   header {
     text-align: center;
   }


### PR DESCRIPTION
## Summary
- lay out the dashboard as a two-column grid so the word table can span the full height
- move folder, group, and word forms into collapsible panels to keep the focus on browsing long lists
- add sticky table headers and scrolling improvements for large word sets

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e4f63f18348323ab5728368acf8f55