### PR TITLE
Adjust star controls layout and refine tablet styling

### DIFF
--- a/app/static/main.js
+++ b/app/static/main.js
@@ -130,9 +130,9 @@ function renderWords() {
       <td>${word.meaning}</td>
       <td>
         <div class="star-cell" data-id="${word.id}">
-          <span class="star-value">${word.star}</span>
-          <button class="star-up" title="별점 +1">▲</button>
-          <button class="star-down" title="별점 -1">▼</button>
+          <button class="star-down" title="별점 낮추기" aria-label="별점 낮추기">−</button>
+          <span class="star-value" aria-live="polite">${word.star}</span>
+          <button class="star-up" title="별점 올리기" aria-label="별점 올리기">＋</button>
         </div>
       </td>
       <td class="word-actions">

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -258,6 +258,45 @@ button.danger {
   border-radius: 6px;
 }
 
+.star-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.08);
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.star-cell .star-value {
+  min-width: 1.4rem;
+  text-align: center;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.star-cell button {
+  padding: 0.25rem 0.55rem;
+  min-width: 2rem;
+  border-radius: 999px;
+  background: white;
+  color: #2563eb;
+  border: 1px solid rgba(37, 99, 235, 0.3);
+  font-size: 0.85rem;
+  font-weight: 700;
+  box-shadow: none;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.star-cell button:hover:not(:disabled) {
+  background: #2563eb;
+  color: white;
+  border-color: #2563eb;
+  box-shadow: none;
+  transform: none;
+}
+
 .form-description {
   font-size: 0.85rem;
   color: #475569;
@@ -538,7 +577,49 @@ tbody tr:hover {
   transform: translateY(0);
 }
 
-@media (max-width: 768px) {
+@media (max-width: 1180px) {
+  body {
+    font-size: 16px;
+  }
+
+  header {
+    padding: 1.25rem 1.5rem;
+  }
+
+  main {
+    padding: 1.25rem;
+    grid-template-columns: repeat(2, minmax(260px, 1fr));
+    grid-template-areas:
+      "words words"
+      "folders groups";
+    max-width: 980px;
+  }
+
+  #words {
+    min-height: 420px;
+  }
+
+  table {
+    font-size: 1rem;
+  }
+
+  .word-controls {
+    flex-wrap: wrap;
+    align-items: flex-end;
+  }
+
+  .word-controls label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .word-controls select {
+    min-width: 120px;
+  }
+}
+
+@media (max-width: 900px) {
   main {
     grid-template-columns: 1fr;
     grid-template-areas: none;


### PR DESCRIPTION
## Summary
- restyle the word rating controls as a horizontal pill with plus/minus buttons
- add responsive refinements so the layout and typography better fit 10" tablets

## Testing
- Manual: Unable to start `uvicorn app.main:app --reload --port 8080` (missing database configuration)


------
https://chatgpt.com/codex/tasks/task_e_68e5088e8e8083239ef8be2693cb6b80