### PR TITLE
Add memorize view for studying words

### DIFF
--- a/app/static/exam.html
+++ b/app/static/exam.html
@@ -13,7 +13,10 @@
           <h1>시험 모드</h1>
           <p>암기한 단어를 확인해보세요.</p>
         </div>
-        <a href="/static/index.html" class="link-button">단어 관리로 이동</a>
+        <div class="header-actions">
+          <a href="/static/index.html" class="link-button">단어 관리</a>
+          <a href="/static/memorize.html" class="link-button">단어 암기</a>
+        </div>
       </div>
     </header>
 

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -13,7 +13,10 @@
           <h1>Remember Word</h1>
           <p>폴더와 그룹을 만들고 단어를 추가해보세요.</p>
         </div>
-        <a href="/static/exam.html" class="link-button">시험 보러 가기</a>
+        <div class="header-actions">
+          <a href="/static/memorize.html" class="link-button">단어 암기</a>
+          <a href="/static/exam.html" class="link-button">시험 보러 가기</a>
+        </div>
       </div>
     </header>
 

--- a/app/static/memorize.html
+++ b/app/static/memorize.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Remember Word - 암기</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="header-content">
+        <div>
+          <h1>단어 암기하기</h1>
+          <p>폴더와 그룹을 선택해 전체 단어 목록을 살펴보세요.</p>
+        </div>
+        <div class="header-actions">
+          <a href="/static/index.html" class="link-button">단어 관리</a>
+          <a href="/static/exam.html" class="link-button">시험 보기</a>
+        </div>
+      </div>
+    </header>
+
+    <main class="memorize-layout">
+      <section class="panel memorize-panel">
+        <div class="panel-header memorize-panel-header">
+          <div class="memorize-heading">
+            <h2>암기 리스트</h2>
+            <p class="panel-subtitle" id="memorize-subtitle">폴더와 그룹을 선택하세요.</p>
+          </div>
+          <div class="memorize-toggle-group">
+            <button id="toggle-term" class="secondary" type="button" disabled>단어 가리기</button>
+            <button id="toggle-meaning" class="secondary" type="button" disabled>뜻 가리기</button>
+          </div>
+        </div>
+
+        <div class="form memorize-selectors">
+          <div class="grid memorize-grid">
+            <label>
+              폴더
+              <select id="memorize-folder">
+                <option value="">폴더 선택</option>
+              </select>
+            </label>
+            <label>
+              그룹
+              <select id="memorize-group" disabled>
+                <option value="">그룹 선택</option>
+              </select>
+            </label>
+          </div>
+        </div>
+
+        <div id="memorize-table-container" class="table-wrapper memorize-table">
+          <table>
+            <thead>
+              <tr>
+                <th>단어</th>
+                <th>뜻</th>
+              </tr>
+            </thead>
+            <tbody id="memorize-word-table">
+              <tr>
+                <td colspan="2" class="empty">폴더와 그룹을 선택하면 단어가 표시됩니다.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+
+    <div id="toast" role="status" aria-live="polite"></div>
+
+    <script src="/static/memorize.js" defer></script>
+  </body>
+</html>

--- a/app/static/memorize.js
+++ b/app/static/memorize.js
@@ -1,0 +1,369 @@
+const state = {
+  folders: [],
+  groups: [],
+  words: [],
+  activeFolderId: null,
+  activeGroupId: null,
+  hideTerm: false,
+  hideMeaning: false,
+  peekTerm: new Set(),
+  peekMeaning: new Set(),
+};
+
+const toast = document.querySelector('#toast');
+const folderSelect = document.querySelector('#memorize-folder');
+const groupSelect = document.querySelector('#memorize-group');
+const subtitle = document.querySelector('#memorize-subtitle');
+const tableBody = document.querySelector('#memorize-word-table');
+const tableContainer = document.querySelector('#memorize-table-container');
+const toggleTermBtn = document.querySelector('#toggle-term');
+const toggleMeaningBtn = document.querySelector('#toggle-meaning');
+
+function showToast(message, type = 'info') {
+  toast.textContent = message;
+  toast.dataset.type = type;
+  toast.classList.add('show');
+  setTimeout(() => toast.classList.remove('show'), 2400);
+}
+
+async function api(path, options = {}) {
+  const res = await fetch(path, {
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    ...options,
+  });
+  if (!res.ok) {
+    let detail = '요청 중 오류가 발생했습니다.';
+    try {
+      const data = await res.json();
+      detail = data.detail || JSON.stringify(data);
+    } catch (err) {
+      // ignore parse error
+    }
+    throw new Error(detail);
+  }
+  const text = await res.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function renderFolders() {
+  folderSelect.innerHTML = '<option value="">폴더 선택</option>';
+  state.folders.forEach((folder) => {
+    const option = document.createElement('option');
+    option.value = folder.id;
+    option.textContent = folder.name;
+    if (folder.id === state.activeFolderId) option.selected = true;
+    folderSelect.appendChild(option);
+  });
+}
+
+function renderGroups() {
+  groupSelect.innerHTML = '';
+  if (!state.activeFolderId) {
+    const option = document.createElement('option');
+    option.value = '';
+    option.textContent = '폴더를 먼저 선택하세요.';
+    option.disabled = true;
+    option.selected = true;
+    groupSelect.appendChild(option);
+    groupSelect.disabled = true;
+    return;
+  }
+
+  if (state.groups.length === 0) {
+    const option = document.createElement('option');
+    option.value = '';
+    option.textContent = '선택할 그룹이 없습니다.';
+    option.disabled = true;
+    option.selected = true;
+    groupSelect.appendChild(option);
+    groupSelect.disabled = true;
+    return;
+  }
+
+  groupSelect.disabled = false;
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = '그룹 선택';
+  placeholder.selected = !state.activeGroupId;
+  groupSelect.appendChild(placeholder);
+  state.groups.forEach((group) => {
+    const option = document.createElement('option');
+    option.value = group.id;
+    option.textContent = group.name;
+    if (group.id === state.activeGroupId) option.selected = true;
+    groupSelect.appendChild(option);
+  });
+
+  if (!state.groups.some((group) => group.id === state.activeGroupId)) {
+    state.activeGroupId = null;
+  }
+}
+
+function updateSubtitle() {
+  if (!state.activeGroupId) {
+    if (state.activeFolderId) {
+      subtitle.textContent = '그룹을 선택하면 단어가 표시됩니다.';
+    } else {
+      subtitle.textContent = '폴더와 그룹을 선택하세요.';
+    }
+    return;
+  }
+
+  subtitle.textContent = `총 ${state.words.length}개의 단어`;
+}
+
+function createCell({ text, hiddenLabel, buttonClass, peeked }) {
+  const cell = document.createElement('td');
+  cell.className = `${buttonClass === 'preview-term' ? 'term-cell' : 'meaning-cell'}`;
+
+  const visibleSpan = document.createElement('span');
+  visibleSpan.className = 'value-text';
+  visibleSpan.textContent = text;
+
+  const hiddenSpan = document.createElement('span');
+  hiddenSpan.className = 'value-hidden';
+  hiddenSpan.textContent = hiddenLabel;
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = `${buttonClass} secondary`;
+  const label = buttonClass === 'preview-term' ? '단어' : '뜻';
+  button.textContent = peeked ? `${label} 숨기기` : `${label} 보기`;
+
+  cell.appendChild(visibleSpan);
+  cell.appendChild(hiddenSpan);
+  cell.appendChild(button);
+  return cell;
+}
+
+function renderWords() {
+  tableBody.innerHTML = '';
+
+  if (!state.activeGroupId) {
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 2;
+    cell.className = 'empty';
+    cell.textContent = '그룹을 선택하면 단어가 표시됩니다.';
+    row.appendChild(cell);
+    tableBody.appendChild(row);
+    updateSubtitle();
+    updateToggleButtons();
+    return;
+  }
+
+  if (state.words.length === 0) {
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 2;
+    cell.className = 'empty';
+    cell.textContent = '등록된 단어가 없습니다.';
+    row.appendChild(cell);
+    tableBody.appendChild(row);
+    updateSubtitle();
+    updateToggleButtons();
+    return;
+  }
+
+  state.words.forEach((word) => {
+    const row = document.createElement('tr');
+    row.dataset.id = word.id;
+
+    if (state.peekTerm.has(word.id)) row.classList.add('peek-term');
+    if (state.peekMeaning.has(word.id)) row.classList.add('peek-meaning');
+
+    const termCell = createCell({
+      text: word.term,
+      hiddenLabel: '단어 숨김',
+      buttonClass: 'preview-term',
+      peeked: state.peekTerm.has(word.id),
+    });
+
+    const meaningCell = createCell({
+      text: word.meaning,
+      hiddenLabel: '뜻 숨김',
+      buttonClass: 'preview-meaning',
+      peeked: state.peekMeaning.has(word.id),
+    });
+
+    row.appendChild(termCell);
+    row.appendChild(meaningCell);
+
+    tableBody.appendChild(row);
+  });
+
+  updateSubtitle();
+  updateToggleButtons();
+}
+
+function updateToggleButtons() {
+  const hasWords = state.words.length > 0;
+  toggleTermBtn.disabled = !hasWords;
+  toggleMeaningBtn.disabled = !hasWords;
+
+  toggleTermBtn.dataset.active = state.hideTerm ? 'true' : 'false';
+  toggleTermBtn.textContent = state.hideTerm ? '단어 모두 보이기' : '단어 가리기';
+
+  toggleMeaningBtn.dataset.active = state.hideMeaning ? 'true' : 'false';
+  toggleMeaningBtn.textContent = state.hideMeaning ? '뜻 모두 보이기' : '뜻 가리기';
+
+  tableContainer.classList.toggle('hide-term', state.hideTerm && hasWords);
+  tableContainer.classList.toggle('hide-meaning', state.hideMeaning && hasWords);
+}
+
+function resetPeekStates() {
+  if (!state.hideTerm) {
+    state.peekTerm.clear();
+  }
+  if (!state.hideMeaning) {
+    state.peekMeaning.clear();
+  }
+}
+
+async function fetchFolders() {
+  try {
+    state.folders = await api('/folders');
+    if (!state.folders.some((folder) => folder.id === state.activeFolderId)) {
+      state.activeFolderId = null;
+      state.groups = [];
+      state.activeGroupId = null;
+      state.words = [];
+    }
+    renderFolders();
+    renderGroups();
+    renderWords();
+  } catch (error) {
+    showToast(error.message, 'error');
+  }
+}
+
+async function fetchGroups() {
+  if (!state.activeFolderId) return;
+  try {
+    state.groups = await api(`/groups?folder_id=${state.activeFolderId}`);
+    renderGroups();
+    if (state.activeGroupId) {
+      await fetchWords();
+    } else {
+      state.words = [];
+      renderWords();
+    }
+  } catch (error) {
+    showToast(error.message, 'error');
+  }
+}
+
+async function fetchWords() {
+  if (!state.activeGroupId) return;
+  try {
+    state.peekTerm.clear();
+    state.peekMeaning.clear();
+    state.words = await api(`/words?group_id=${state.activeGroupId}`);
+    renderWords();
+  } catch (error) {
+    showToast(error.message, 'error');
+  }
+}
+
+folderSelect.addEventListener('change', () => {
+  const value = Number(folderSelect.value);
+  state.activeFolderId = Number.isFinite(value) && value > 0 ? value : null;
+  state.activeGroupId = null;
+  state.groups = [];
+  state.words = [];
+  state.hideTerm = false;
+  state.hideMeaning = false;
+  resetPeekStates();
+  renderGroups();
+  renderWords();
+  if (state.activeFolderId) {
+    fetchGroups();
+  }
+});
+
+groupSelect.addEventListener('change', () => {
+  const value = Number(groupSelect.value);
+  state.activeGroupId = Number.isFinite(value) && value > 0 ? value : null;
+  state.words = [];
+  state.hideTerm = false;
+  state.hideMeaning = false;
+  resetPeekStates();
+  renderWords();
+  if (state.activeGroupId) {
+    fetchWords();
+  }
+});
+
+function handlePeekToggle(id, type) {
+  const set = type === 'term' ? state.peekTerm : state.peekMeaning;
+  if (set.has(id)) {
+    set.delete(id);
+  } else {
+    set.add(id);
+  }
+}
+
+function updateRowButtons(row) {
+  const id = Number(row.dataset.id);
+  const termButton = row.querySelector('.preview-term');
+  const meaningButton = row.querySelector('.preview-meaning');
+
+  if (termButton) {
+    const peeked = state.peekTerm.has(id);
+    termButton.textContent = peeked ? '단어 숨기기' : '단어 보기';
+    row.classList.toggle('peek-term', peeked);
+  }
+
+  if (meaningButton) {
+    const peeked = state.peekMeaning.has(id);
+    meaningButton.textContent = peeked ? '뜻 숨기기' : '뜻 보기';
+    row.classList.toggle('peek-meaning', peeked);
+  }
+}
+
+tableBody.addEventListener('click', (event) => {
+  const button = event.target.closest('button');
+  if (!button) return;
+
+  const row = button.closest('tr');
+  if (!row || !row.dataset.id) return;
+
+  const id = Number(row.dataset.id);
+  if (button.classList.contains('preview-term')) {
+    if (!state.hideTerm) return;
+    handlePeekToggle(id, 'term');
+    updateRowButtons(row);
+    return;
+  }
+
+  if (button.classList.contains('preview-meaning')) {
+    if (!state.hideMeaning) return;
+    handlePeekToggle(id, 'meaning');
+    updateRowButtons(row);
+  }
+});
+
+toggleTermBtn.addEventListener('click', () => {
+  if (!state.words.length) return;
+  state.hideTerm = !state.hideTerm;
+  if (!state.hideTerm) {
+    state.peekTerm.clear();
+  }
+  renderWords();
+});
+
+toggleMeaningBtn.addEventListener('click', () => {
+  if (!state.words.length) return;
+  state.hideMeaning = !state.hideMeaning;
+  if (!state.hideMeaning) {
+    state.peekMeaning.clear();
+  }
+  renderWords();
+});
+
+fetchFolders();

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -26,6 +26,13 @@ header {
   flex-wrap: wrap;
 }
 
+.header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  justify-content: flex-end;
+}
+
 header h1 {
   margin: 0 0 0.25rem;
   font-size: 1.8rem;
@@ -80,6 +87,122 @@ main.exam-layout {
 
 main.exam-layout .panel {
   width: min(100%, 760px);
+}
+
+main.memorize-layout {
+  display: flex;
+  justify-content: center;
+  padding: 2.5rem 1.5rem 3rem;
+  max-width: 900px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+main.memorize-layout .panel {
+  width: min(100%, 820px);
+}
+
+.memorize-panel-header {
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.memorize-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.memorize-toggle-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.memorize-selectors {
+  gap: 1rem;
+}
+
+.memorize-grid {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.memorize-table {
+  flex: 1;
+}
+
+.memorize-table .empty {
+  text-align: center;
+  color: #64748b;
+  padding: 1.5rem 0;
+}
+
+.term-cell,
+.meaning-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.term-cell .value-text {
+  font-weight: 600;
+}
+
+.value-text {
+  display: inline;
+}
+
+.value-hidden {
+  display: none;
+  color: #94a3b8;
+}
+
+.preview-term,
+.preview-meaning {
+  display: none;
+  align-self: flex-start;
+  font-size: 0.85rem;
+  padding: 0.4rem 0.75rem;
+}
+
+.memorize-table.hide-term .term-cell .value-text {
+  display: none;
+}
+
+.memorize-table.hide-term .term-cell .value-hidden {
+  display: inline;
+}
+
+.memorize-table.hide-term .term-cell .preview-term {
+  display: inline-flex;
+}
+
+.memorize-table.hide-term tr.peek-term .term-cell .value-text {
+  display: inline;
+}
+
+.memorize-table.hide-term tr.peek-term .term-cell .value-hidden {
+  display: none;
+}
+
+.memorize-table.hide-meaning .meaning-cell .value-text {
+  display: none;
+}
+
+.memorize-table.hide-meaning .meaning-cell .value-hidden {
+  display: inline;
+}
+
+.memorize-table.hide-meaning .meaning-cell .preview-meaning {
+  display: inline-flex;
+}
+
+.memorize-table.hide-meaning tr.peek-meaning .meaning-cell .value-text {
+  display: inline;
+}
+
+.memorize-table.hide-meaning tr.peek-meaning .meaning-cell .value-hidden {
+  display: none;
 }
 
 #folders {
@@ -238,6 +361,11 @@ button {
 button.secondary {
   background: rgba(37, 99, 235, 0.1);
   color: #1f2937;
+}
+
+button.secondary[data-active="true"] {
+  background: rgba(37, 99, 235, 0.22);
+  color: #1d4ed8;
 }
 
 button.primary {
@@ -642,6 +770,14 @@ tbody tr:hover {
     width: 100%;
   }
 
+  main.memorize-layout {
+    padding: 2rem 1rem 2.5rem;
+  }
+
+  main.memorize-layout .panel {
+    width: 100%;
+  }
+
   .group-select-actions {
     width: 100%;
     justify-content: flex-start;
@@ -654,6 +790,10 @@ tbody tr:hover {
   .header-content {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .header-actions {
+    justify-content: center;
   }
 
   .link-button {


### PR DESCRIPTION
## Summary
- add a dedicated memorize page that lists words for a selected folder/group with hide-and-preview controls
- wire the new page into the existing navigation links and style it for desktop/mobile layouts
- extend shared styles for toggle buttons and the memorize table states

## Testing
- not run (DB_URL environment variable is not configured in the container)

------
https://chatgpt.com/codex/tasks/task_e_68e50ac2e180832396bc62c5320a850c