### PR TITLE
Fix boolean defaults for quiz session retry flag

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -46,7 +46,7 @@ def ensure_schema() -> None:
         if "is_retry" not in quiz_session_columns:
             connection.execute(
                 text(
-                    "ALTER TABLE quiz_sessions ADD COLUMN is_retry BOOLEAN NOT NULL DEFAULT 0"
+                    "ALTER TABLE quiz_sessions ADD COLUMN is_retry BOOLEAN NOT NULL DEFAULT FALSE"
                 )
             )
 

--- a/app/models.py
+++ b/app/models.py
@@ -8,6 +8,7 @@ from sqlalchemy import (
     func,
     UniqueConstraint,
     Boolean,
+    text,
 )
 from sqlalchemy.orm import relationship
 from database import Base
@@ -71,7 +72,7 @@ class QuizSession(Base):
     total_questions = Column(Integer, nullable=False)
     answered_questions = Column(Integer, nullable=False, default=0)
     correct_questions = Column(Integer, nullable=False, default=0)
-    is_retry = Column(Boolean, nullable=False, default=False, server_default="0")
+    is_retry = Column(Boolean, nullable=False, default=False, server_default=text("false"))
     created_at = Column(DateTime, server_default=func.now())
     profile = relationship("Profile", back_populates="sessions")
     group = relationship("Group", back_populates="quiz_sessions")


### PR DESCRIPTION
## Summary
- ensure the is_retry column is created with a proper BOOLEAN default in ensure_schema
- align the ORM model with a PostgreSQL-compatible server default for the is_retry flag

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e521bf7d248323a2f9a7c00bbf2bf1