### PR TITLE
Keep group panel anchored with long word lists

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -69,8 +69,8 @@ main {
   grid-template-areas:
     "folders words"
     "groups words";
-  grid-auto-rows: minmax(280px, 1fr);
-  align-items: stretch;
+  grid-template-rows: auto 1fr;
+  align-items: start;
   min-height: calc(100vh - 6rem);
   max-width: 1200px;
   margin: 0 auto;
@@ -276,6 +276,7 @@ main.memorize-layout .panel {
 #words {
   grid-area: words;
   min-height: 100%;
+  align-self: stretch;
 }
 
 .panel {


### PR DESCRIPTION
## Summary
- adjust the main grid layout to use an auto/1fr row setup and top alignment
- ensure the word panel stretches while folders and groups stay pinned to the top

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e526844670832385048235337a5896