### PR TITLE
Add manual language selection for memorize audio

### DIFF
--- a/app/static/memorize.html
+++ b/app/static/memorize.html
@@ -51,6 +51,25 @@
             <button id="toggle-term" class="secondary" type="button" disabled>단어 가리기</button>
             <button id="toggle-meaning" class="secondary" type="button" disabled>뜻 가리기</button>
           </div>
+          <fieldset class="audio-language-control">
+            <legend>발음 언어</legend>
+            <label>
+              <input type="radio" name="audio-language" value="auto" checked />
+              자동
+            </label>
+            <label>
+              <input type="radio" name="audio-language" value="en-US" />
+              영어
+            </label>
+            <label>
+              <input type="radio" name="audio-language" value="ko-KR" />
+              한글
+            </label>
+            <label>
+              <input type="radio" name="audio-language" value="zh-CN" />
+              한자
+            </label>
+          </fieldset>
         </div>
 
         <div id="memorize-table-container" class="table-wrapper memorize-table">

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -127,6 +127,40 @@ main.memorize-layout .panel {
   justify-content: flex-end;
   align-items: center;
   gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.audio-language-control {
+  margin: 0;
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  background: rgba(59, 130, 246, 0.08);
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.45rem 0.85rem;
+  min-height: 2.25rem;
+  flex-wrap: wrap;
+}
+
+.audio-language-control legend {
+  padding: 0 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #1d4ed8;
+}
+
+.audio-language-control label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  color: #1e293b;
+  white-space: nowrap;
+}
+
+.audio-language-control input[type='radio'] {
+  accent-color: #1d4ed8;
 }
 
 .memorize-selectors {


### PR DESCRIPTION
## Summary
- add a pronunciation language selector to the memorize page controls
- update the memorize script to honor the selected language and improve speech button labels
- style the new selector to match the existing layout

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e5a1b25fc48323be0816345fce3244