### PR TITLE
Add favicon and header logo integration

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from fastapi.staticfiles import StaticFiles
 
 BASE_DIR = Path(__file__).resolve().parent
 STATIC_DIR = BASE_DIR / "static"
+IMAGES_DIR = BASE_DIR / "images"
 
 if str(BASE_DIR) not in sys.path:
     sys.path.append(str(BASE_DIR))
@@ -18,6 +19,9 @@ app = FastAPI(title="Remember Word", version="1.0")
 
 if STATIC_DIR.exists():
     app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+
+if IMAGES_DIR.exists():
+    app.mount("/images", StaticFiles(directory=IMAGES_DIR), name="images")
 
 
 ensure_schema()

--- a/app/static/exam.html
+++ b/app/static/exam.html
@@ -4,14 +4,23 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Remember Word - 시험</title>
+    <link rel="icon" type="image/x-icon" href="/images/remember_word_log.ico" />
+    <link rel="icon" type="image/png" href="/images/remember_word_log.png" />
     <link rel="stylesheet" href="/static/styles.css" />
   </head>
   <body>
     <header>
       <div class="header-content">
-        <div>
-          <h1>시험 모드</h1>
-          <p>암기한 단어를 확인해보세요.</p>
+        <div class="header-brand">
+          <img
+            src="/images/remember_word_log.png"
+            alt="Remember Word 로고"
+            class="header-logo"
+          />
+          <div>
+            <h1>시험 모드</h1>
+            <p>암기한 단어를 확인해보세요.</p>
+          </div>
         </div>
         <div class="header-actions">
           <a href="/static/index.html" class="link-button">단어 관리</a>

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -4,14 +4,23 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Remember Word</title>
+    <link rel="icon" type="image/x-icon" href="/images/remember_word_log.ico" />
+    <link rel="icon" type="image/png" href="/images/remember_word_log.png" />
     <link rel="stylesheet" href="/static/styles.css" />
   </head>
   <body>
     <header>
       <div class="header-content">
-        <div>
-          <h1>Remember Word</h1>
-          <p>폴더와 그룹을 만들고 단어를 추가해보세요.</p>
+        <div class="header-brand">
+          <img
+            src="/images/remember_word_log.png"
+            alt="Remember Word 로고"
+            class="header-logo"
+          />
+          <div>
+            <h1>Remember Word</h1>
+            <p>폴더와 그룹을 만들고 단어를 추가해보세요.</p>
+          </div>
         </div>
         <div class="header-actions">
           <a href="/static/memorize.html" class="link-button">단어 암기</a>

--- a/app/static/memorize.html
+++ b/app/static/memorize.html
@@ -4,14 +4,23 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Remember Word - 암기</title>
+    <link rel="icon" type="image/x-icon" href="/images/remember_word_log.ico" />
+    <link rel="icon" type="image/png" href="/images/remember_word_log.png" />
     <link rel="stylesheet" href="/static/styles.css" />
   </head>
   <body>
     <header>
       <div class="header-content">
-        <div>
-          <h1>단어 암기하기</h1>
-          <p>폴더와 그룹을 선택해 전체 단어 목록을 살펴보세요.</p>
+        <div class="header-brand">
+          <img
+            src="/images/remember_word_log.png"
+            alt="Remember Word 로고"
+            class="header-logo"
+          />
+          <div>
+            <h1>단어 암기하기</h1>
+            <p>폴더와 그룹을 선택해 전체 단어 목록을 살펴보세요.</p>
+          </div>
         </div>
         <div class="header-actions">
           <a href="/static/index.html" class="link-button">단어 관리</a>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -26,6 +26,22 @@ header {
   flex-wrap: wrap;
 }
 
+.header-brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.header-logo {
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.18);
+  padding: 0.5rem;
+  box-sizing: border-box;
+  object-fit: contain;
+}
+
 .header-actions {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- mount the `/images` directory so the new favicon and logo can be served
- add favicon links and embed the application logo across the static pages
- style the header layout to accommodate the new brand logo

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e5cfeff47c83239c7ceb846528e54d