### PR TITLE
Align exam group checkbox layout

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -648,6 +648,7 @@ tbody tr:hover {
   font-size: 0.95rem;
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: 0.4rem;
   overflow-y: auto;
 }
@@ -663,17 +664,25 @@ tbody tr:hover {
 }
 
 .group-checkbox-item {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr;
   align-items: center;
+  justify-items: start;
   gap: 0.55rem;
   font-size: 0.95rem;
   color: #1f2937;
+  width: 100%;
 }
 
 .group-checkbox-item input[type='checkbox'] {
   width: 1.1rem;
   height: 1.1rem;
   flex-shrink: 0;
+}
+
+.group-checkbox-item span {
+  text-align: left;
+  width: 100%;
 }
 
 .group-placeholder {


### PR DESCRIPTION
## Summary
- align the exam group checkbox list so the checkbox and label sit side by side on the left
- ensure group labels span the full width for consistent alignment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5e837ee308323bd075c5181e99281